### PR TITLE
Add y axis label to co2 graph

### DIFF
--- a/images/ny-power-web/static/js/mqtt.js
+++ b/images/ny-power-web/static/js/mqtt.js
@@ -80,7 +80,12 @@ function onMessageArrived(message) {
                 type: 'scatter'
             }
         ];
-        Plotly.newPlot('co2_graph', plot);
+        var layout = {
+            yaxis: {
+                title: "g CO2 / kWh",
+            }
+        };
+        Plotly.newPlot('co2_graph', plot, layout);
     }
     if (message.destinationName == "ny-power/application/webui") {
         if (message.payloadString == "reload") {


### PR DESCRIPTION
This commit adds a y axis label to the CO2 graph. While the unit is
printed above the chart with the current number (and the page title)
it's not always clear what units the graph is. To make it a bit clearer
this commit adds a yaxis to the graph.