### PR TITLE
Undefined name HOST: Change to INFLUXDB_HOST?

### DIFF
--- a/images/ny-power-web/app.py
+++ b/images/ny-power-web/app.py
@@ -34,7 +34,7 @@ def mqtt():
 
 @app.route("/current/co2")
 def current_co2():
-    client = InfluxDBClient(HOST, 8086, 'root', 'root', 'fuel-mix')
+    client = InfluxDBClient(INFLUXDB_HOST, 8086, 'root', 'root', 'fuel-mix')
     results = client.query("select last(value) from co2_current")
     points = results.get_points()
     val = next(points)
@@ -42,7 +42,7 @@ def current_co2():
 
 @app.route("/range/co2")
 def range_co2():
-    client = InfluxDBClient(HOST, 8086, 'root', 'root', 'fuel-mix')
+    client = InfluxDBClient(INFLUXDB_HOST, 8086, 'root', 'root', 'fuel-mix')
     results = client.query("select value from co2_current")
     points = results.get_points()
 


### PR DESCRIPTION
__HOST__ is an undefined name in this context...

flake8 testing of https://github.com/ibm/ny-power on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./images/ny-power-web/app.py:37:29: F821 undefined name 'HOST'
    client = InfluxDBClient(HOST, 8086, 'root', 'root', 'fuel-mix')
                            ^
./images/ny-power-web/app.py:45:29: F821 undefined name 'HOST'
    client = InfluxDBClient(HOST, 8086, 'root', 'root', 'fuel-mix')
                            ^
2     F821 undefined name 'HOST'
2
```